### PR TITLE
Apply Ryan's "sparse" branch changes to cleaned-up "ctx":

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -15,6 +15,7 @@ from typing import Any, Union, Optional  # Meta
 from typing import Iterable, Sequence, Mapping, MutableMapping  # Generic ABCs
 from typing import Tuple, List  # Generic
 
+from dask import array as da
 import h5py
 from natsort import natsorted
 import numpy as np
@@ -528,6 +529,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     X = X.astype(dtype)
             elif isinstance(X, ZarrArray):
                 X = X.astype(dtype)
+            elif isinstance(X, da.Array):
+                print(f'Pass Dask array: {X}')
+                pass
             else:  # is np.ndarray or a subclass, convert to true np.ndarray
                 X = np.array(X, dtype, copy=False)
             # data matrix and shape
@@ -1814,7 +1818,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if "obs" in key and len(self._obs) != self._n_obs:
             raise ValueError(
                 "Observations annot. `obs` must have number of rows of `X`"
-                f" ({self._n_obs}), but has {self._obs.shape[0]} rows."
+                f" ({self._n_obs}), but has {len(self._obs)} rows (shape {self._obs.shape[0]})."
             )
         if "var" in key and len(self._var) != self._n_vars:
             raise ValueError(

--- a/anndata/tests/test_chunk.py
+++ b/anndata/tests/test_chunk.py
@@ -104,6 +104,7 @@ def test_dask_dataframe_hdf5_load_group():
 
         assert_index_equal(ddf.columns, df.columns)
         assert_frame_equal(ddf.compute(), df)
+        assert ddf.partition_sizes == [100]*10
 
 
 def test_dask_dataframe_hdf5_load_dataset():


### PR DESCRIPTION
### What this changes

This applies the changes in @ryan-williams 's `sparse` branch onto the new `ctx` branch of `anndata`, which has some cleaned-up history.

```
commit 8204895ca0e15fb58d83eb5e24c0315ca50ac964 (origin/sparse, sparse)
Author: Ryan Williams <ryan@runsascoded.com>
Date:   Mon May 4 03:42:17 2020 +0000

    set partition_sizes when loading dask dataframe from hdf5

commit c2e4e36344d07c48f42d57a5db18f2a848cd1355
Author: Ryan Williams <ryan@runsascoded.com>
Date:   Sun May 3 18:25:54 2020 +0000

    wip sparse dask array loading for scanpy
```

