### PR TITLE
Set the meta when constructing a daskified X to an appropriate type of empty matrix.

### DIFF
--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -70,8 +70,12 @@ def _normalize_index(
 
     if is_dask(indexer):
         if is_dask(index):
-            # both are dask
-            return daskify_call(_normalize_index, indexer, index)
+            if isinstance(indexer, dd.Series):
+                indexer = slice(0, len(indexer), 1)
+            else:
+                raise ValueError("Attempting to normalize dask index swith a dask indexer!  Use a dask series Indexer instead.")
+                # This works technically, but is too opaque to be useful.
+                # return daskify_call(_normalize_index, indexer, index)
         else:
             # just the indexer is dask
             return indexer.map(lambda ixr: _normalize_index(ixr, index))

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -246,7 +246,7 @@ class AnnDataDask(AnnData):
     def to_dask_delayed(self, *args, _debug:bool=False, **kwargs):
         if self.is_view:
             def _compute_anndata_view(adata_ref, oidx, vidx):
-                adata_ref.__class__(adata_ref, oidx=oidx, vidx=vidx, asview=True)
+                return adata_ref.__class__(adata_ref, oidx=oidx, vidx=vidx, asview=True)
             virtual = daskify_call(_compute_anndata_view, self._adata_ref.to_dask_delayed(), self._oidx, self._vidx)
             return virtual
 

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -221,7 +221,7 @@ class AnnDataDask(AnnData):
 
     @property
     def X(self):
-        if self._X is None:
+        if getattr(self, "_X", None) is None:
             if self.is_view:
                 X = self._adata_ref.X[self._oidx, self._vidx]
             else:

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -173,8 +173,8 @@ class AnnDataDask(AnnData):
             # because we will have a circularity problem.  Plus it may never.
             def mk_axis_arrays(obs, var, vals_raw):
                 safe_copy = self._raw_copy()
-                self._obs = obs
-                self._var = var
+                safe_copy._obs = obs
+                safe_copy._var = var
                 return AxisArrays(safe_copy, axis, vals=convert_to_dict(vals_raw))
             return daskify_call(mk_axis_arrays, self.obs, self.var, vals_raw)
         elif is_dask(vals_raw):
@@ -369,17 +369,11 @@ class AnnDataDask(AnnData):
             return read_h5ad(filename, backed=mode, dask=True)
 
     def _raw_copy(self):
-        # TODO: This triggers an odd error later in the code when turned-on.
-        # It is unclear if it is really needed where it is used.  If so, debug.
-        # "Series getitem in only supported for other series objects "
-        return self
-        """
         cls = self.__class__
         new = cls.__new__(cls)
         for attr, val in self.__dict__.items():
             setattr(new, attr, val)
         return new
-        """
 
     def copy_with_changes(self: "AnnDataDask", **kwargs):
         kw = dict(


### PR DESCRIPTION
### What this changes:

#### Sparse metadata:

When we load X via dask, the previous code set the meta as an ndarray, even though the actual returned type is csr_matrix.

This sets the meta correctly.

#### Dask indexes and indexers

When we do filtering, the indexer and the index are possibly daskified, since it is impossible to know which rows match before the data is loaded.

There is a _normalize_indexes function that gets daskified by default, but if the indexer is a Dask Series it can produce a concrete answer immediately.  Opting for this allows downstream code to operate intelligently w/o touching the data.

####  Remove Debug Code from AnnDataDask._raw_copy()

The initial implementation of _raw_copy() had debug code that disabled it.  Now it is enabled.  The debug functionality returned self, but the code that calls it needs to be able to mutate the copy safely.

#### AnnDataDask views and the `.X` virtual property:

There were two typos in the `.X` accessor, now both fixed.

