### PR TITLE
Slicing

### DIFF
--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -85,7 +85,7 @@ def test_cmp_new_old_h5ad(dask):
 
 def filter_on_self_sum(ad):
     ad.obs["umi_counts"] = ad.X.sum(axis=1).A.flatten()
-    adv = ad[ad.obs["umi_counts"] > 100.0]
+    adv = ad[ad.obs["umi_counts"] > 10.0]
     return adv
 
 
@@ -157,15 +157,15 @@ def test_dask_load(path):
     ))
 
     # Higher level ops are defined as functions above.
-    check(
-        filter_on_self_sum,
-    )
-    
+    #check(
+    #    filter_on_self_sum,
+    #)
+
     # For these to work, we need to update how dask dataframes work,
     # or use a custom dataframe subclass with more features.
     # Either case will possibly use normalization like the AnnDataDask.__get_item__(),
     # since that method does successfully create indexes that will slice an obs or var.
-    TODO2 = [
+    TODO2 = (
         # iloc'ing row(s)/col(s) mostly does not work out, of the box:
         lambda ad: ad.obs.loc['2', 'Prime'],
 
@@ -185,7 +185,8 @@ def test_dask_load(path):
 
         # works, but Dask returns a Series (to Pandas' scalar)
         lambda ad: ad.obs.loc['10', 'label'],
-    ]
+    )
+    check(TODO2)
 
 
 class PreventedMethodCallException(Exception):

--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -84,17 +84,6 @@ def test_cmp_new_old_h5ad(dask):
     #     ad.write_h5ad(path)
 
 
-def test_spmatrix_bool_slice():
-    from scipy.sparse import csc_matrix, spmatrix
-    from scipy import sparse
-
-    csc = sparse.random(10, 10, density=0.1, format='csc')
-    rows = [True]*10
-    l = csc[rows]
-    l = l.A
-    A = csc.A
-    r = A[rows]
-    assert_array_equal(l, r)
 
 @pytest.mark.parametrize('path', [
     old_path,
@@ -163,6 +152,9 @@ def test_dask_load(path):
 
     check(lambda ad: ad.X.sum(axis=1).A.flatten())
 
+    # These all work individually, but multiple in sequence fail, probably due to the
+    # "umi_counts" column being assigned, and that actually mutating things.
+
     # def assign_umi_counts(ad):
     #     ad.obs["umi_counts"] = ad.X.sum(axis=1).A.flatten()
     #     return ad
@@ -188,12 +180,6 @@ def test_dask_load(path):
         return adv
 
     check(filter_on_self_sum)
-
-    # For these to work, we need to update how dask dataframes work,
-    # or use a custom dataframe subclass with more features.
-    # Either case will possibly use normalization like the AnnDataDask.__get_item__(),
-    # since that method does successfully create indexes that will slice an obs or var.
-    # iloc'ing row(s)/col(s) mostly does not work out, of the box:
 
     # Pandas squeezes a dimension out of these (i.e. Series -> int, or DataFrame ->
     # Series; Dask should be able to detect at build time that it's going to happen,

--- a/anndata/tests/utils/eq.py
+++ b/anndata/tests/utils/eq.py
@@ -78,8 +78,8 @@ from pandas.testing import assert_frame_equal
 def _(l, r):
     if isinstance(r, DaskMethodsMixin):
         r = r.compute()
-    if l.index.names == [None] and r.index.names == ["_index"]:
-        l.index.names = ["_index"]
+    if l.index.names == ["_index"] and r.index.names == [None]:
+        r.index.names = ["_index"]
     assert_frame_equal(l, r)
 
 

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -427,6 +427,9 @@ def _(anno, length, index_names):
 
 
 def daskify_iloc(df, idx):
+    # Now works in dask.
+    return df.iloc[idx]
+    """
     def call_iloc(df_, idx_):
         return df_.iloc[idx_]
     meta = df._meta
@@ -434,7 +437,7 @@ def daskify_iloc(df, idx):
         pass
     df = daskify_call_return_df(call_iloc, df, idx, _dask_meta=meta)
     return df
-
+    """
 
 
 def daskify_get_len_given_index(index: slice, orig_len: int):

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -11,25 +11,26 @@
 # - Other functions and objects may or may not have dask-awareness internally.
 #   ^^ Ideally we remove this too, but it is trickier.
 #
-from collections import OrderedDict
 from copy import deepcopy
 import functools
+from functools import singledispatch
 from os import PathLike
-from typing import Any, Union, Optional  # Meta
-from typing import Iterable, Sequence, Mapping, MutableMapping, Tuple, List  # Generic ABCs
+from typing import Union, Optional  # Meta
+from typing import MutableMapping, Tuple, List  # Generic ABCs
 import warnings
 
 import numpy as np
-from numpy import ma
+from numpy import dtype, nan, ndarray
 import pandas as pd
-from pandas.api.types import is_string_dtype, is_categorical
+from pandas.api.types import is_string_dtype
 from scipy import sparse
-from scipy.sparse import issparse
 
 import dask
+from dask import delayed
 import dask.dataframe
 from dask.dataframe import Series
 import dask.array
+from dask.array import from_delayed, concatenate
 from dask.array.backends import register_scipy_sparse
 
 from anndata._core.anndata import _gen_dataframe
@@ -47,9 +48,6 @@ from anndata._core.views import (
 )
 from anndata.utils import convert_to_dict
 from anndata.logging import anndata_logger as logger
-from anndata.compat import (
-    _slice_uns_sparse_matrices,
-)
 
 
 register_scipy_sparse()
@@ -57,6 +55,184 @@ register_scipy_sparse()
 
 def is_dask(obj) -> bool:
     return isinstance(obj, dask.base.DaskMethodsMixin)
+
+
+def normalize_slice(idxr, size):
+    m = idxr.start or 0
+    M = idxr.stop if idxr.stop is not None else size
+    Δ = idxr.step or 1
+    if m < 0: m += size
+    if M < 0: M += size
+    m, M = min(m, M), max(m, M)
+    m = np.clip(m, 0, size)
+    M = np.clip(M, 0, size)
+    if Δ < 0:
+        Δ = -Δ
+        m += (M-m)%Δ
+
+    return m, M, Δ
+
+
+def bools_to_ints(bools: Union[pd.Series, ndarray]):
+    '''Convert a bool-Series to an int-Series representing the indices where True was found.
+
+    - reset_index twice to get a column of auto-incrementing ints (the initial index may be e.g. strings)
+    - restore the original index
+    - slice using the original booleans (along the original index)
+    - take the first column (the pre-slice auto-incrementing integers)
+    '''
+    assert bools.dtype == dtype(bool)
+    sliced = \
+        bools \
+            .reset_index(drop=True) \
+            .reset_index() \
+            .set_index(bools.index) \
+            [bools]
+    return sliced[sliced.columns[0]]
+
+
+def maybe_bools_to_ints(slicer):
+    if isinstance(slicer, (pd.Series, ndarray)) and slicer.dtype == dtype(bool):
+        return bools_to_ints(slicer)
+    else:
+        return slicer
+
+
+@singledispatch
+def partition_idxr(idxr, partition_sizes):
+    '''Given an indexer and list of partition sizes, return a map from [partition idx]
+    to [indexer containing elements corresponding to that partition].
+
+    The latter can be an in-memory or Dask object; in either case, overlapping
+    partitions can be zipped and the indexer applied to each partition's elements.
+    '''
+    raise NotImplementedError('%s: %s' % (type(idxr), idxr))
+
+@partition_idxr.register(slice)
+@partition_idxr.register(range)
+def _(idxr, partition_sizes):
+    partition_slices = {}
+    if not partition_sizes:
+        return partition_slices
+    partition_ends = np.cumsum(partition_sizes).tolist()
+    size = partition_ends[-1]
+    partition_idx_ranges = zip(
+        [0] + partition_ends,
+        partition_ends,
+    )
+
+    m, M, Δ = normalize_slice(idxr, size)
+
+    for partition_idx, (start, end) in enumerate(partition_idx_ranges):
+        if start < M and end > m:
+            if start >= m:
+                first = (start - m) % Δ
+            else:
+                first = m
+            last = min(end, M) - start
+            partition_slices[partition_idx] = slice(first, last, Δ)
+
+    return partition_slices
+
+@partition_idxr.register(list)
+@partition_idxr.register(tuple)
+def _(idxr, partition_sizes):
+    '''Break a list of integer indices into sets that can be applied within partitions.
+
+    Example:
+    - idxr: [2,3,5,8,13,21,34,55]
+    - partition_sizes: [10,20,30])
+    - return: { 0: [2,3,5,8], 1: [3,11], 2: [4,25] }
+
+    (Note that the 13, 21, 34, and 55 are converted to the relative offsets within
+    partitions 1 and 2 (which start at indices 10 and 30, resp.)
+
+    TODO: factor with similar block in dataframe iloc?
+
+    :param idxr: integer indices
+    :param partition_sizes:
+    :return: map from [ partition index ] to [ relative indices on that partition
+        corresponding to its intersection with `idxr` ]
+    '''
+    idxr = tuple(idxr)
+    partition_idx_lists = {}
+    if not partition_sizes:
+        return partition_idx_lists
+    cur_partition_idxs = []
+    idx_pos = 0
+    num_idxs = len(idxr)
+    partition_ends = np.cumsum(partition_sizes).tolist()
+    size = partition_ends[-1]
+    npartitions = len(partition_ends)
+    partition_idx = 0
+    cur_partition_end = partition_ends[0]
+    while idx_pos < num_idxs:
+        idx = idxr[idx_pos]
+        if idx < 0: idx += size
+        while idx >= cur_partition_end:
+            if cur_partition_idxs:
+                partition_idx_lists[partition_idx] = cur_partition_idxs
+                cur_partition_idxs = []
+            partition_idx += 1
+            if partition_idx == npartitions:
+                break
+            cur_partition_end = partition_ends[partition_idx]
+        cur_partition_idxs.append(idx)
+        idx_pos += 1
+    if cur_partition_idxs:
+        partition_idx_lists[partition_idx] = cur_partition_idxs
+
+    return partition_idx_lists
+@partition_idxr.register(pd.Series)
+def _(idxr, partition_sizes):
+    return partition_idxr(idxr.values, partition_sizes)
+
+@partition_idxr.register(ndarray)
+def _(idxr, partition_sizes):
+    if idxr.dtype == dtype(int):
+        return partition_idxr(idxr.tolist(), partition_sizes)
+    elif idxr.dtype == dtype(bool):
+        size = sum(partition_sizes)
+        if len(idxr) != size:
+            raise ValueError(
+                'Slicing with bool Series of size %d but partition sizes sum to %d (%s)' % (
+                    len(idxr), size, partition_sizes
+                )
+            )
+        return partition_idxr(bools_to_ints(idxr), partition_sizes)
+    else:
+        raise NotImplementedError
+
+@partition_idxr.register(Series)
+def _(idxr, partition_sizes):
+    if idxr.dtype == dtype(int):
+        # TODO: is this case doable?
+        # if not idxr.known_divisions:
+        #     raise ValueError("Can't slice with a Dask series of ints with unknown divisions: %s" % idxr)
+        # divisions = tuple(zip(idxr.divisions, idxr.divisions[1:]))
+        raise NotImplementedError
+    elif idxr.dtype == dtype(bool):
+        if idxr.partition_sizes != partition_sizes:
+            raise ValueError(
+                "Bool dask.dataframe.Series partition_sizes don't match slicee's: %s vs %s; %s" % (
+                    idxr.partition_sizes, partition_sizes, idxr
+                )
+            )
+        return {
+            idx: idxr.partitions[idx]
+            for idx in range(idxr.npartitions)
+        }
+    else:
+        raise NotImplementedError('%s: %s' % (type(idxr), idxr))
+
+
+def slice_block(X, oidx, vidx):
+    oidx = maybe_bools_to_ints(oidx)
+    vidx = maybe_bools_to_ints(vidx)
+    sliced = X[oidx, vidx]
+    return sliced
+
+slice_block = delayed(slice_block)
 
 
 class AnnDataDask(AnnData):
@@ -242,26 +418,41 @@ class AnnDataDask(AnnData):
         if getattr(self, "_X", None) is None:
             if self.is_view:
                 refX: dask.array.Array = self._adata_ref.X
-                def getitem(x, oidx, vidx):
-                    return x[oidx, vidx]
 
-                if self.obs.partition_sizes is None:
-                    ax0_chunks = [np.nan] * self.obs.npartitions
-                else:
-                    ax0_chunks = self.obs.partition_sizes
+                X = refX
+                oidx = self._oidx
+                vidx = self._vidx
 
-                if self.var.partition_sizes is None:
-                    ax1_chunks = [np.nan] * self.var.npartitions
-                else:
-                    ax1_chunks = self.var.partition_sizes
+                oidx = partition_idxr(oidx, X.chunks[0])
+                vidx = partition_idxr(vidx, X.chunks[1])
 
-                viewX = refX.map_blocks(
-                    getitem,
-                    self._oidx, self._vidx,
-                    meta=refX._meta,
-                    chunks=(ax0_chunks, ax1_chunks)
-                )
-                return viewX
+                chunks = X.chunks
+                R, C = len(chunks[0]), len(chunks[1])
+                result = \
+                    concatenate(
+                        [
+                            concatenate(
+                                [
+                                    from_delayed(
+                                        slice_block(
+                                            X.blocks[r, c],
+                                            oidx.get(r, []),
+                                            vidx.get(c, []),
+                                        ),
+                                        shape=(nan, nan),
+                                        dtype=X.dtype,
+                                        meta=X._meta,
+                                        name='%s-sliced-%s-%s' % (X._name, r, c),
+                                    )
+                                    for c in range(C)
+                                ],
+                                axis=1,
+                            )
+                            for r in range(R)
+                        ]
+                    )
+
+                return result
             else:
                 X = load_dask_array(path=self.file.filename, key='X',
                                     chunk_size=(self._n_obs, "auto"),


### PR DESCRIPTION
### What this changes:

This updates `AnnDataDask` to use the new `.iloc` support, discarding the temporary wrapper that allowed `iloc` to function in ways that wouldn't scale with large multi-sample virtual concatenations.

The `AnnDataDask` class no longer needs a special "view" mode when slicing to subsets of rows.  Using indexers or slices uses dask to get more powerful views, and cuts out the complexity of the old view layer.

This change also re-implements the logic that defines X such that it could be a concatenation of multiple Xs from individual files, and then be logically filtered down to a subset of each, as in the example from the notebook `ad2 = ad1[ad1.obs["umi_counts"]>1000.0]`

And it updates the test cases with newly passing tests, and other refactoring to make it faster to see which tests leads to an error when one or more fail.
