### PR TITLE
Update the AnnDataDask constructor to handle when the X argument is passed and is not None.

### DIFF
--- a/anndata/tests/test_dask.py
+++ b/anndata/tests/test_dask.py
@@ -59,8 +59,6 @@ def test_cmp_new_old_h5ad(dask):
     old = load_ad(old_path)
     new = load_ad(new_path)
 
-    print(old.nnz[:20])
-    print(new.nnz[:20])
     assert old.nnz == new.nnz
 
     from pandas.testing import assert_frame_equal
@@ -68,8 +66,6 @@ def test_cmp_new_old_h5ad(dask):
     # old AnnData's set DFs' index.name to "index", new style leaves it None
     old.obs.index.name = None
     old.var.index.name = None
-
-    print(old.obs.index)
 
     if old.obs.index.names == [None] and new.obs.index.names == ["_index"]:
         old.obs.index.names = ["_index"]

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -264,11 +264,13 @@ class AnnDataDask(AnnData):
         filemode=None,
         fd=None
     ):
-        AnnData._init_as_actual(self, X, obs, var, uns, obsm, varm, varp, obsp, raw, layers, dtype, shape, filename, filemode, fd)
-        X = load_dask_array(path=self.file.filename, key='X',
-                            chunk_size=(self._n_obs, "auto"),
-                            shape=self.shape)
-        self._X = X
+        if X is None:
+            if self.file is None:
+                raise ValueError("Expected either a filename or X argument!")
+            X = load_dask_array(path=self.file.filename, key='X',
+                                chunk_size=(self._n_obs, "auto"),
+                                format_str='csr', shape=self.shape)
+        super()._init_as_actual(X, obs, var, uns, obsm, varm, varp, obsp, raw, layers, dtype, shape, filename, filemode, fd)
 
     @classmethod
     def slice_df(cls, df, idx: Index):

--- a/anndata_dask.py
+++ b/anndata_dask.py
@@ -265,11 +265,9 @@ class AnnDataDask(AnnData):
         fd=None
     ):
         if X is None:
-            if self.file is None:
+            if filename is None:
                 raise ValueError("Expected either a filename or X argument!")
-            X = load_dask_array(path=self.file.filename, key='X',
-                                chunk_size=(self._n_obs, "auto"),
-                                format_str='csr', shape=self.shape)
+            X = load_dask_array(path=filename, key='X',)
         super()._init_as_actual(X, obs, var, uns, obsm, varm, varp, obsp, raw, layers, dtype, shape, filename, filemode, fd)
 
     @classmethod


### PR DESCRIPTION
The AnnDataDask constructor refactor missed the case in which the filename is not specified, but an X value is passed-in.  This occurs when we virtually concatenate the per-sample AnnDataDask objects into a multisample.

Untested...